### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@master
 
     - name: Publish Docker Image to GPR
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       id: docker
       with:
         name: docker.pkg.github.com/mmedum/docker-mkdocs/mkdocs


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore